### PR TITLE
Fixing parse errors

### DIFF
--- a/sdks/php/lib/vendor/Apigee/Usergrid/Collection.php
+++ b/sdks/php/lib/vendor/Apigee/Usergrid/Collection.php
@@ -282,11 +282,11 @@ class Collection {
     $data->previous = $this->previous;
     $data->next = $this->next;
     $data->cursor = $this->cursor;
-    $data->list=[];
+    $data->list = array();
     $this->reset_entity_pointer();
     while ($this->has_next_entity()) {
         $entity = $this->get_next_entity();
-        array_push($data->list, $entity->get_json())
+        array_push($data->list, $entity->get_json());
     }
     return json_encode($data);
   }


### PR DESCRIPTION
When trying to run your PHP quickstart example I encountered these two errors immediately:

PHP Parse error:  syntax error, unexpected '[' in /lib/vendor/Apigee/Usergrid/Collection.php on line 285
PHP Parse error:  syntax error, unexpected '}' in /lib/vendor/Apigee/Usergrid/Collection.php on line 290

Which are caused a missing semi-colon on line 289 and attempting to create an array with [] instead of the constructor function array() on line 285.
