### PR TITLE
Fix for build breakage caused by RAT

### DIFF
--- a/stack/pom.xml
+++ b/stack/pom.xml
@@ -1765,27 +1765,37 @@
             </executions>
             <configuration>
                 <excludes>
-                    <exclude>.idea/**</exclude>
-                    <exclude>.git/**</exclude>
-                    <exclude>m2/**</exclude>
-                    <exclude>.gitignore</exclude>
+
+                    <exclude>**/README.md</exclude>
+                    <exclude>**/CHANGES.txt</exclude>
+
+                    <!-- git and IDE project files -->
+                    <exclude>**/.git/**</exclude>
+                    <exclude>**/.gitignore</exclude>
+                    <exclude>**..idea/**</exclude>
+                    <exclude>**/*.iml</exclude>
+                    <exclude>**/nbactions.xml</exclude>
+                    <exclude>**/nb-configuration.xml</exclude>
                     <exclude>**/.classpath/**</exclude>
                     <exclude>**/.project</exclude>
-                    <exclude>**/*.iml</exclude>
                     <exclude>**/.settings/**</exclude>
-                    <exclude>**/*.asc</exclude>
+
+                    <!-- temporary build files -->
                     <exclude>**/logs/**</exclude>
                     <exclude>**/docs/**</exclude>
-                    <exclude>CHANGES.txt</exclude>
-                    <exclude>cloudbees.xml</exclude>
-                    <exclude>README.md</exclude>
-                    <exclude>**/src/test/resources/**</exclude>
-                    <exclude>**dependency-reduced-pom.xml</exclude>
-                    <exclude>**/src/test/resources/*.txt</exclude>
+                    <exclude>**/tmp/**</exclude>
                     <exclude>**/target/**</exclude>
                     <exclude>**/antlr3/**</exclude>
                     <exclude>**/META-INF/**</exclude>
+                    <exclude>**/dependency-reduced-pom.xml</exclude>
                     <exclude>**/QueryFilter.tokens</exclude>
+
+                    <!-- other -->
+                    <exclude>**/m2/**</exclude>
+                    <exclude>**/*.asc</exclude>
+                    <exclude>**/src/test/resources/**</exclude>
+                    <exclude>**/cloudbees.xml</exclude>
+
                 </excludes>
             </configuration>
 

--- a/stack/services/src/test/java/org/apache/usergrid/services/ServiceFactoryIT.java
+++ b/stack/services/src/test/java/org/apache/usergrid/services/ServiceFactoryIT.java
@@ -25,7 +25,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.apache.usergrid.cassandra.Concurrent;
 
-import org.usergrid.simple.SimpleService;
+import org.apache.usergrid.services.simple.SimpleService;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;

--- a/stack/services/src/test/java/org/apache/usergrid/services/simple/SimpleService.java
+++ b/stack/services/src/test/java/org/apache/usergrid/services/simple/SimpleService.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.usergrid.simple;
+package org.apache.usergrid.services.simple;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;


### PR DESCRIPTION
RAT was breaking my build because I have some Netbeans project files around so I added some exclusions. Also added an exclusion for a tmp directory that was causing RAT to fail.

Also: moved SimpleService to the new package naming scheme.
