### PR TITLE
USERGRID-117 Add Apache license headers to UGC

### DIFF
--- a/ugc/Gemfile
+++ b/ugc/Gemfile
@@ -1,2 +1,17 @@
+#Licensed to the Apache Software Foundation (ASF) under one or more contributor
+#license agreements.  See the NOTICE.txt file distributed with this work for
+#additional information regarding copyright ownership.  The ASF licenses this
+#file to you under the Apache License, Version 2.0 (the "License"); you may not
+#use this file except in compliance with the License.  You may obtain a copy of
+#the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+#Unless required by applicable law or agreed to in writing, software
+#distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+#License for the specific language governing permissions and limitations under
+#the License.
+
 source 'https://rubygems.org'
 gemspec

--- a/ugc/Gemfile.lock
+++ b/ugc/Gemfile.lock
@@ -1,3 +1,19 @@
+#Licensed to the Apache Software Foundation (ASF) under one or more contributor
+#license agreements.  See the NOTICE.txt file distributed with this work for
+#additional information regarding copyright ownership.  The ASF licenses this
+#file to you under the Apache License, Version 2.0 (the "License"); you may not
+#use this file except in compliance with the License.  You may obtain a copy of
+#the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+#Unless required by applicable law or agreed to in writing, software
+#distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+#License for the specific language governing permissions and limitations under
+#the License.
+
+
 PATH
   remote: .
   specs:

--- a/ugc/README.md
+++ b/ugc/README.md
@@ -1,6 +1,6 @@
 # Usergrid Command Line (ugc)
 
-ugc enables convenient terminal access to Apigee's App Services (aka Usergrid).
+ugc enables convenient terminal access to Apache Usergrid.
 
 ## Features
 
@@ -261,16 +261,18 @@ If you specify column names in your query, you will be unable to reference the r
 
 
 ## Copyright
-Copyright (c) 2013 Scott Ganyo
+Licensed to the Apache Software Foundation (ASF) under one or more contributor
+license agreements.  See the NOTICE.txt file distributed with this work for
+additional information regarding copyright ownership.  The ASF licenses this
+file to you under the Apache License, Version 2.0 (the "License"); you may not
+use this file except in compliance with the License.  You may obtain a copy of
+the License at
 
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use the included files except in compliance with the License.
+     http://www.apache.org/licenses/LICENSE-2.0
 
-You may obtain a copy of the License at
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+License for the specific language governing permissions and limitations under
+the License.
 
-  <http://www.apache.org/licenses/LICENSE-2.0>
-
-Unless required by applicable law or agreed to in writing, software distributed under
-the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
-either express or implied. See the License for the specific language governing permissions and
-limitations under the License.

--- a/ugc/Rakefile
+++ b/ugc/Rakefile
@@ -1,3 +1,18 @@
+#Licensed to the Apache Software Foundation (ASF) under one or more contributor
+#license agreements.  See the NOTICE.txt file distributed with this work for
+#additional information regarding copyright ownership.  The ASF licenses this
+#file to you under the Apache License, Version 2.0 (the "License"); you may not
+#use this file except in compliance with the License.  You may obtain a copy of
+#the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+#Unless required by applicable law or agreed to in writing, software
+#distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+#License for the specific language governing permissions and limitations under
+#the License.
+
 require "bundler/gem_tasks"
 
 require 'rake/clean'

--- a/ugc/bin/ugc
+++ b/ugc/bin/ugc
@@ -1,3 +1,18 @@
+#Licensed to the Apache Software Foundation (ASF) under one or more contributor
+#license agreements.  See the NOTICE.txt file distributed with this work for
+#additional information regarding copyright ownership.  The ASF licenses this
+#file to you under the Apache License, Version 2.0 (the "License"); you may not
+#use this file except in compliance with the License.  You may obtain a copy of
+#the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+#Unless required by applicable law or agreed to in writing, software
+#distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+#License for the specific language governing permissions and limitations under
+#the License.
+
 #!/usr/bin/env ruby
 
 require 'gli'

--- a/ugc/features/step_definitions/ugc_steps.rb
+++ b/ugc/features/step_definitions/ugc_steps.rb
@@ -1,3 +1,18 @@
+#Licensed to the Apache Software Foundation (ASF) under one or more contributor
+#license agreements.  See the NOTICE.txt file distributed with this work for
+#additional information regarding copyright ownership.  The ASF licenses this
+#file to you under the Apache License, Version 2.0 (the "License"); you may not
+#use this file except in compliance with the License.  You may obtain a copy of
+#the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+#Unless required by applicable law or agreed to in writing, software
+#distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+#License for the specific language governing permissions and limitations under
+#the License.
+
 When /^I get help for "([^"]*)"$/ do |app_name|
   @app_name = app_name
   step %(I run `#{app_name} help`)

--- a/ugc/features/support/env.rb
+++ b/ugc/features/support/env.rb
@@ -1,3 +1,18 @@
+#Licensed to the Apache Software Foundation (ASF) under one or more contributor
+#license agreements.  See the NOTICE.txt file distributed with this work for
+#additional information regarding copyright ownership.  The ASF licenses this
+#file to you under the Apache License, Version 2.0 (the "License"); you may not
+#use this file except in compliance with the License.  You may obtain a copy of
+#the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+#Unless required by applicable law or agreed to in writing, software
+#distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+#License for the specific language governing permissions and limitations under
+#the License.
+
 require 'aruba/cucumber'
 
 ENV['PATH'] = "#{File.expand_path(File.dirname(__FILE__) + '/../../bin')}#{File::PATH_SEPARATOR}#{ENV['PATH']}"

--- a/ugc/lib/ugc.rb
+++ b/ugc/lib/ugc.rb
@@ -1,3 +1,18 @@
+#Licensed to the Apache Software Foundation (ASF) under one or more contributor
+#license agreements.  See the NOTICE.txt file distributed with this work for
+#additional information regarding copyright ownership.  The ASF licenses this
+#file to you under the Apache License, Version 2.0 (the "License"); you may not
+#use this file except in compliance with the License.  You may obtain a copy of
+#the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+#Unless required by applicable law or agreed to in writing, software
+#distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+#License for the specific language governing permissions and limitations under
+#the License.
+
 require 'ugc/version.rb'
 
 # Add requires for other files you add to your project here, so

--- a/ugc/lib/ugc/application.rb
+++ b/ugc/lib/ugc/application.rb
@@ -1,3 +1,18 @@
+#Licensed to the Apache Software Foundation (ASF) under one or more contributor
+#license agreements.  See the NOTICE.txt file distributed with this work for
+#additional information regarding copyright ownership.  The ASF licenses this
+#file to you under the Apache License, Version 2.0 (the "License"); you may not
+#use this file except in compliance with the License.  You may obtain a copy of
+#the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+#Unless required by applicable law or agreed to in writing, software
+#distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+#License for the specific language governing permissions and limitations under
+#the License.
+
 module Ugc
   class Application < Usergrid::Application
 

--- a/ugc/lib/ugc/commands/delete.rb
+++ b/ugc/lib/ugc/commands/delete.rb
@@ -1,3 +1,18 @@
+#Licensed to the Apache Software Foundation (ASF) under one or more contributor
+#license agreements.  See the NOTICE.txt file distributed with this work for
+#additional information regarding copyright ownership.  The ASF licenses this
+#file to you under the Apache License, Version 2.0 (the "License"); you may not
+#use this file except in compliance with the License.  You may obtain a copy of
+#the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+#Unless required by applicable law or agreed to in writing, software
+#distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+#License for the specific language governing permissions and limitations under
+#the License.
+
 desc 'delete an entity'
 arg_name 'url'
 

--- a/ugc/lib/ugc/commands/get.rb
+++ b/ugc/lib/ugc/commands/get.rb
@@ -1,3 +1,18 @@
+#Licensed to the Apache Software Foundation (ASF) under one or more contributor
+#license agreements.  See the NOTICE.txt file distributed with this work for
+#additional information regarding copyright ownership.  The ASF licenses this
+#file to you under the Apache License, Version 2.0 (the "License"); you may not
+#use this file except in compliance with the License.  You may obtain a copy of
+#the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+#Unless required by applicable law or agreed to in writing, software
+#distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+#License for the specific language governing permissions and limitations under
+#the License.
+
 desc 'retrieve and display a collection or entity'
 
 command :get,:show,:ls,:list do |c|

--- a/ugc/lib/ugc/commands/login.rb
+++ b/ugc/lib/ugc/commands/login.rb
@@ -1,3 +1,18 @@
+#Licensed to the Apache Software Foundation (ASF) under one or more contributor
+#license agreements.  See the NOTICE.txt file distributed with this work for
+#additional information regarding copyright ownership.  The ASF licenses this
+#file to you under the Apache License, Version 2.0 (the "License"); you may not
+#use this file except in compliance with the License.  You may obtain a copy of
+#the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+#Unless required by applicable law or agreed to in writing, software
+#distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+#License for the specific language governing permissions and limitations under
+#the License.
+
 require 'io/console'
 
 desc 'Performs a login to the current profile'

--- a/ugc/lib/ugc/commands/post.rb
+++ b/ugc/lib/ugc/commands/post.rb
@@ -1,3 +1,18 @@
+#Licensed to the Apache Software Foundation (ASF) under one or more contributor
+#license agreements.  See the NOTICE.txt file distributed with this work for
+#additional information regarding copyright ownership.  The ASF licenses this
+#file to you under the Apache License, Version 2.0 (the "License"); you may not
+#use this file except in compliance with the License.  You may obtain a copy of
+#the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+#Unless required by applicable law or agreed to in writing, software
+#distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+#License for the specific language governing permissions and limitations under
+#the License.
+
 desc 'non-idempotent create or update (post is usually create)'
 arg_name '[path] [data]'
 

--- a/ugc/lib/ugc/commands/profile.rb
+++ b/ugc/lib/ugc/commands/profile.rb
@@ -1,3 +1,18 @@
+#Licensed to the Apache Software Foundation (ASF) under one or more contributor
+#license agreements.  See the NOTICE.txt file distributed with this work for
+#additional information regarding copyright ownership.  The ASF licenses this
+#file to you under the Apache License, Version 2.0 (the "License"); you may not
+#use this file except in compliance with the License.  You may obtain a copy of
+#the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+#Unless required by applicable law or agreed to in writing, software
+#distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+#License for the specific language governing permissions and limitations under
+#the License.
+
 desc "set the current profile (creates if it doesn't exist)"
 arg_name 'profile name'
 

--- a/ugc/lib/ugc/commands/put.rb
+++ b/ugc/lib/ugc/commands/put.rb
@@ -1,3 +1,18 @@
+#Licensed to the Apache Software Foundation (ASF) under one or more contributor
+#license agreements.  See the NOTICE.txt file distributed with this work for
+#additional information regarding copyright ownership.  The ASF licenses this
+#file to you under the Apache License, Version 2.0 (the "License"); you may not
+#use this file except in compliance with the License.  You may obtain a copy of
+#the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+#Unless required by applicable law or agreed to in writing, software
+#distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+#License for the specific language governing permissions and limitations under
+#the License.
+
 desc 'idempotent create or update (put is usually an update)'
 arg_name '[path] [data]'
 

--- a/ugc/lib/ugc/commands/query.rb
+++ b/ugc/lib/ugc/commands/query.rb
@@ -1,3 +1,18 @@
+#Licensed to the Apache Software Foundation (ASF) under one or more contributor
+#license agreements.  See the NOTICE.txt file distributed with this work for
+#additional information regarding copyright ownership.  The ASF licenses this
+#file to you under the Apache License, Version 2.0 (the "License"); you may not
+#use this file except in compliance with the License.  You may obtain a copy of
+#the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+#Unless required by applicable law or agreed to in writing, software
+#distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+#License for the specific language governing permissions and limitations under
+#the License.
+
 desc 'query (uses sql-like syntax)'
 long_desc 'query may contain "from" clause instead of specifying collection_name'
 arg_name '[collection_name] query'

--- a/ugc/lib/ugc/commands/target.rb
+++ b/ugc/lib/ugc/commands/target.rb
@@ -1,3 +1,18 @@
+#Licensed to the Apache Software Foundation (ASF) under one or more contributor
+#license agreements.  See the NOTICE.txt file distributed with this work for
+#additional information regarding copyright ownership.  The ASF licenses this
+#file to you under the Apache License, Version 2.0 (the "License"); you may not
+#use this file except in compliance with the License.  You may obtain a copy of
+#the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+#Unless required by applicable law or agreed to in writing, software
+#distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+#License for the specific language governing permissions and limitations under
+#the License.
+
 desc 'set the base url, org, and app for the current profile'
 
 command :target do |c|

--- a/ugc/lib/ugc/helpers/curl.rb
+++ b/ugc/lib/ugc/helpers/curl.rb
@@ -1,3 +1,18 @@
+#Licensed to the Apache Software Foundation (ASF) under one or more contributor
+#license agreements.  See the NOTICE.txt file distributed with this work for
+#additional information regarding copyright ownership.  The ASF licenses this
+#file to you under the Apache License, Version 2.0 (the "License"); you may not
+#use this file except in compliance with the License.  You may obtain a copy of
+#the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+#Unless required by applicable law or agreed to in writing, software
+#distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+#License for the specific language governing permissions and limitations under
+#the License.
+
 def puts_curl(command, resource, payload=nil, file=nil)
   headers = resource.options[:headers] || {}
   req = RestClient::Request.new(resource.options.merge(

--- a/ugc/lib/ugc/helpers/format.rb
+++ b/ugc/lib/ugc/helpers/format.rb
@@ -1,3 +1,18 @@
+#Licensed to the Apache Software Foundation (ASF) under one or more contributor
+#license agreements.  See the NOTICE.txt file distributed with this work for
+#additional information regarding copyright ownership.  The ASF licenses this
+#file to you under the Apache License, Version 2.0 (the "License"); you may not
+#use this file except in compliance with the License.  You may obtain a copy of
+#the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+#Unless required by applicable law or agreed to in writing, software
+#distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+#License for the specific language governing permissions and limitations under
+#the License.
+
 SKIP_ATTRS = %w(metadata uri type)
 INDEX_COL_WIDTH = 2
 

--- a/ugc/lib/ugc/helpers/history.rb
+++ b/ugc/lib/ugc/helpers/history.rb
@@ -1,3 +1,18 @@
+#Licensed to the Apache Software Foundation (ASF) under one or more contributor
+#license agreements.  See the NOTICE.txt file distributed with this work for
+#additional information regarding copyright ownership.  The ASF licenses this
+#file to you under the Apache License, Version 2.0 (the "License"); you may not
+#use this file except in compliance with the License.  You may obtain a copy of
+#the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+#Unless required by applicable law or agreed to in writing, software
+#distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+#License for the specific language governing permissions and limitations under
+#the License.
+
 def save_response(response)
   if response && response.multiple_entities? && response.collection.size > 1
     paths = response.entities.collect {|e| e['metadata']['path'][1..-1] } rescue []

--- a/ugc/lib/ugc/helpers/parse.rb
+++ b/ugc/lib/ugc/helpers/parse.rb
@@ -1,3 +1,18 @@
+#Licensed to the Apache Software Foundation (ASF) under one or more contributor
+#license agreements.  See the NOTICE.txt file distributed with this work for
+#additional information regarding copyright ownership.  The ASF licenses this
+#file to you under the Apache License, Version 2.0 (the "License"); you may not
+#use this file except in compliance with the License.  You may obtain a copy of
+#the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+#Unless required by applicable law or agreed to in writing, software
+#distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+#License for the specific language governing permissions and limitations under
+#the License.
+
 require 'json'
 
 def parse_sql(query)

--- a/ugc/lib/ugc/helpers/rest.rb
+++ b/ugc/lib/ugc/helpers/rest.rb
@@ -1,3 +1,18 @@
+#Licensed to the Apache Software Foundation (ASF) under one or more contributor
+#license agreements.  See the NOTICE.txt file distributed with this work for
+#additional information regarding copyright ownership.  The ASF licenses this
+#file to you under the Apache License, Version 2.0 (the "License"); you may not
+#use this file except in compliance with the License.  You may obtain a copy of
+#the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+#Unless required by applicable law or agreed to in writing, software
+#distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+#License for the specific language governing permissions and limitations under
+#the License.
+
 def multipart_payload(payload, file)
   payload = payload.is_a?(Hash) ? payload : MultiJson.load(payload)
   filename = 'file'

--- a/ugc/lib/ugc/management.rb
+++ b/ugc/lib/ugc/management.rb
@@ -1,3 +1,18 @@
+#Licensed to the Apache Software Foundation (ASF) under one or more contributor
+#license agreements.  See the NOTICE.txt file distributed with this work for
+#additional information regarding copyright ownership.  The ASF licenses this
+#file to you under the Apache License, Version 2.0 (the "License"); you may not
+#use this file except in compliance with the License.  You may obtain a copy of
+#the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+#Unless required by applicable law or agreed to in writing, software
+#distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+#License for the specific language governing permissions and limitations under
+#the License.
+
 module Ugc
   class Management < Usergrid::Management
 

--- a/ugc/lib/ugc/settings.rb
+++ b/ugc/lib/ugc/settings.rb
@@ -1,3 +1,18 @@
+#Licensed to the Apache Software Foundation (ASF) under one or more contributor
+#license agreements.  See the NOTICE.txt file distributed with this work for
+#additional information regarding copyright ownership.  The ASF licenses this
+#file to you under the Apache License, Version 2.0 (the "License"); you may not
+#use this file except in compliance with the License.  You may obtain a copy of
+#the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+#Unless required by applicable law or agreed to in writing, software
+#distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+#License for the specific language governing permissions and limitations under
+#the License.
+
 module Ugc
   class Settings
 

--- a/ugc/lib/ugc/version.rb
+++ b/ugc/lib/ugc/version.rb
@@ -1,3 +1,18 @@
+#Licensed to the Apache Software Foundation (ASF) under one or more contributor
+#license agreements.  See the NOTICE.txt file distributed with this work for
+#additional information regarding copyright ownership.  The ASF licenses this
+#file to you under the Apache License, Version 2.0 (the "License"); you may not
+#use this file except in compliance with the License.  You may obtain a copy of
+#the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+#Unless required by applicable law or agreed to in writing, software
+#distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+#License for the specific language governing permissions and limitations under
+#the License.
+
 module Ugc
   VERSION = '0.9.9'
 end

--- a/ugc/test/default_test.rb
+++ b/ugc/test/default_test.rb
@@ -1,3 +1,18 @@
+#Licensed to the Apache Software Foundation (ASF) under one or more contributor
+#license agreements.  See the NOTICE.txt file distributed with this work for
+#additional information regarding copyright ownership.  The ASF licenses this
+#file to you under the Apache License, Version 2.0 (the "License"); you may not
+#use this file except in compliance with the License.  You may obtain a copy of
+#the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+#Unless required by applicable law or agreed to in writing, software
+#distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+#License for the specific language governing permissions and limitations under
+#the License.
+
 require 'test_helper'
 
 class DefaultTest < Test::Unit::TestCase

--- a/ugc/test/test_helper.rb
+++ b/ugc/test/test_helper.rb
@@ -1,3 +1,18 @@
+#Licensed to the Apache Software Foundation (ASF) under one or more contributor
+#license agreements.  See the NOTICE.txt file distributed with this work for
+#additional information regarding copyright ownership.  The ASF licenses this
+#file to you under the Apache License, Version 2.0 (the "License"); you may not
+#use this file except in compliance with the License.  You may obtain a copy of
+#the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+#Unless required by applicable law or agreed to in writing, software
+#distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+#License for the specific language governing permissions and limitations under
+#the License.
+
 require 'test/unit'
 
 # Add test libraries you want to use here, e.g. mocha

--- a/ugc/ugc.gemspec
+++ b/ugc/ugc.gemspec
@@ -1,3 +1,18 @@
+#Licensed to the Apache Software Foundation (ASF) under one or more contributor
+#license agreements.  See the NOTICE.txt file distributed with this work for
+#additional information regarding copyright ownership.  The ASF licenses this
+#file to you under the Apache License, Version 2.0 (the "License"); you may not
+#use this file except in compliance with the License.  You may obtain a copy of
+#the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+#Unless required by applicable law or agreed to in writing, software
+#distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+#License for the specific language governing permissions and limitations under
+#the License.
+
 # Ensure we require the local version and not one we might have installed already
 require File.join([File.dirname(__FILE__),'lib','ugc','version.rb'])
 spec = Gem::Specification.new do |s| 


### PR DESCRIPTION
Trivial license header update. Some changes to README are also included to update doc links etc.
