### PR TITLE
removing dynamic_property when value is empty

### DIFF
--- a/stack/core/src/main/java/org/apache/usergrid/persistence/AbstractEntity.java
+++ b/stack/core/src/main/java/org/apache/usergrid/persistence/AbstractEntity.java
@@ -267,7 +267,13 @@ public abstract class AbstractEntity implements Entity {
     @Override
     @JsonAnySetter
     public void setDynamicProperty( String key, Object value ) {
-        dynamic_properties.put( key, value );
+        if (value.equals("")) {
+			if (dynamic_properties.containsKey(key)) {
+				dynamic_properties.remove(key);
+			}
+		} else {
+			dynamic_properties.put(key, value);
+		}
     }
 
 


### PR DESCRIPTION
This changes remove the dynamic property when the corresponding value for that property is empty. 
Bug Fixing for https://issues.apache.org/jira/browse/USERGRID-21
