### PR TITLE
Bugfix: missing dollar signs in get_connections()

### DIFF
--- a/sdks/php/lib/vendor/Apache/Usergrid/Entity.php
+++ b/sdks/php/lib/vendor/Apache/Usergrid/Entity.php
@@ -291,11 +291,11 @@ class Entity {
     $this->set($connection,array());
 
     $length = count($result->entities);
-    for ($i = 0; i < $length; $i++) {
-      if ($result['entities'][i]['type'] == 'user') {
-        $this[$connection][$result['entities'][i]['username']] = $result['entities'][i];
+    for ($i = 0; $i < $length; $i++) {
+      if ($result['entities'][$i]['type'] == 'user') {
+        $this[$connection][$result['entities'][$i]['username']] = $result['entities'][$i];
       } else {
-        $this[$connection][$result['entities'][i]['name']] = $result['entities'][i];
+        $this[$connection][$result['entities'][$i]['name']] = $result['entities'][$i];
       }
     }
   }


### PR DESCRIPTION
Hey there.

Just found this typo in yout php sdk.
I think this will fix it but wasn't able to test the fix yet...

Greets, Tim.

I am contributing code under the terms of the Apache Software License.
