### PR TITLE
FIX: notices and errors in get_connections()

### DIFF
--- a/sdks/php/lib/vendor/Apache/Usergrid/Entity.php
+++ b/sdks/php/lib/vendor/Apache/Usergrid/Entity.php
@@ -281,7 +281,7 @@ class Entity {
 
   public function get_connections($connection) {
     $connectorType = $this->get('type');
-    $connector = md_dtl_Apigee_Usergrid_Entity::get_entity_id($this);
+    $connector = Entity::get_entity_id($this);
     if (!$connector) {
       return;
     }

--- a/sdks/php/lib/vendor/Apache/Usergrid/Entity.php
+++ b/sdks/php/lib/vendor/Apache/Usergrid/Entity.php
@@ -281,23 +281,28 @@ class Entity {
 
   public function get_connections($connection) {
     $connectorType = $this->get('type');
-    $connector = Entity::get_entity_id($this);
+    $connector = md_dtl_Apigee_Usergrid_Entity::get_entity_id($this);
     if (!$connector) {
       return;
     }
 
     $endpoint = $connectorType . '/' . $connector . '/' . $connection . '/';
     $result=$this->client->get($endpoint, array());
-    $this->set($connection,array());
 
-    $length = count($result->entities);
+    $connected_entities = array();
+
+    $response_data = $result->get_data();
+    $length        = count($response_data['entities']);
+    
     for ($i = 0; $i < $length; $i++) {
-      if ($result['entities'][$i]['type'] == 'user') {
-        $this[$connection][$result['entities'][$i]['username']] = $result['entities'][$i];
+      $tmp_entity = $response_data['entities'][$i];
+      if ($tmp_entity['type'] == 'user') {
+          $connected_entities[$tmp_entity['username']] = $tmp_entity;
       } else {
-        $this[$connection][$result['entities'][$i]['name']] = $result['entities'][$i];
+          $connected_entities[$tmp_entity['name']]     = $tmp_entity;
       }
     }
+    $this->set($connection, $connected_entities);
   }
 
   public function get_connecting($connection) {


### PR DESCRIPTION
Hey there.

Now that I found the time to test the method "get_connections" (see https://github.com/usergrid/usergrid/pull/130) I found some other bugs in it:

The method get_connections() tries to determine the count of connected entities in a faulty way.
This raises an "undefined property" notice.
Once this is line of code is fixed one gets the following error:

"PHP Fatal error:  Cannot use object of type Entity as array in ..."

This is caused by the following code:
"$this[$connection][$result['entities'][$i]['username']] = $result['entities'][$i];"

Introduced a temporary variable "$tmp_entity" in the for loop for more readability.

Greets, Tim.

I am contributing code under the terms of the Apache Software License.
