### PR TITLE
Add corepersistence to pom

### DIFF
--- a/stack/corepersistence/collection/pom.xml
+++ b/stack/corepersistence/collection/pom.xml
@@ -13,6 +13,7 @@
   <description>The module for handling all scope I/O</description>
 
   <artifactId>collection</artifactId>
+  <name>Usergrid Collection</name>
 
   <build>
 

--- a/stack/corepersistence/common/pom.xml
+++ b/stack/corepersistence/common/pom.xml
@@ -10,6 +10,7 @@
   <modelVersion>4.0.0</modelVersion>
 
   <artifactId>common</artifactId>
+  <name>Usergrid Common</name>
 
   <dependencies>
 

--- a/stack/corepersistence/graph/pom.xml
+++ b/stack/corepersistence/graph/pom.xml
@@ -31,6 +31,8 @@
 
   <artifactId>graph</artifactId>
 
+  <name>Usergrid Graph</name>
+
   <dependencies>
 
     <dependency>

--- a/stack/corepersistence/model/pom.xml
+++ b/stack/corepersistence/model/pom.xml
@@ -10,6 +10,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>model</artifactId>
+    <name>Usergrid Model</name>
 
   <properties>
     <jackson-2-version>2.3.1</jackson-2-version>

--- a/stack/corepersistence/pom.xml
+++ b/stack/corepersistence/pom.xml
@@ -4,11 +4,11 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <name>core-persistence</name>
     <description>Prototype for refactoring persistence of usergrid</description>
 
     <groupId>org.apache.usergrid</groupId>
     <artifactId>persistence</artifactId>
+    <name>Usergrid Persistence</name>
     <packaging>pom</packaging>
     <version>2.0.0-SNAPSHOT</version>
 

--- a/stack/corepersistence/queryindex/pom.xml
+++ b/stack/corepersistence/queryindex/pom.xml
@@ -13,6 +13,7 @@
     <description>Module provates indexing and query of Entities via ElasticSearch</description>
 
     <artifactId>queryindex</artifactId>
+    <name>Usergrid Queryindex</name>
 
     <build>
 

--- a/stack/pom.xml
+++ b/stack/pom.xml
@@ -187,6 +187,7 @@
 
   <modules>
     <module>config</module>
+    <module>corepersistence</module>
     <module>core</module>
     <module>services</module>
     <module>tools</module>


### PR DESCRIPTION
/stack/pom.xml was missing corepersisence module, causing build failure if corepersistence wasn't previously built. To reproduce:

```
rm -rf ~/.m2/repository/org/apache/usergrid/*/2.0.0-SNAPSHOT
cd stack
mvn clean install -DskipTests
```

Also added module names for consistency
