### PR TITLE
 Provide auto-injected environment parameters in cluster setup

### DIFF
--- a/chop/client/src/main/java/org/apache/usergrid/chop/client/ssh/Job.java
+++ b/chop/client/src/main/java/org/apache/usergrid/chop/client/ssh/Job.java
@@ -114,7 +114,7 @@ public class Job implements Callable<ResponseInfo> {
                 LOG.info( "SSH command response: {}", message );
             }
             while ( ( message = errorReader.readLine() ) != null ) {
-                response.addErrorMessage( message );
+                response.addMessage( message );
                 LOG.info( "Error in ssh command: {}", message );
             }
 

--- a/chop/webapp/src/main/java/org/apache/usergrid/chop/webapp/coordinator/CoordinatorUtils.java
+++ b/chop/webapp/src/main/java/org/apache/usergrid/chop/webapp/coordinator/CoordinatorUtils.java
@@ -228,11 +228,17 @@ public class CoordinatorUtils {
 
         /** export instance IPs and host names as a space separated list with ClusterName suffixed by _HOSTS and _ADDRS   */
         StringBuilder ipList = new StringBuilder();
+        StringBuilder privateIpList = new StringBuilder();
         StringBuilder hostList = new StringBuilder();
+        StringBuilder privateHostList = new StringBuilder();
         for ( Instance temp : cluster.getInstances() ) {
-            ipList.append( temp.getPrivateIpAddress() )
+            ipList.append( temp.getPublicIpAddress() )
+                    .append( " " );
+            privateIpList.append( temp.getPrivateIpAddress() )
                     .append( " " );
             hostList.append( temp.getPublicDnsName() )
+                    .append( " " );
+            privateHostList.append( temp.getPrivateDnsName() )
                     .append( " " );
         }
 
@@ -244,8 +250,20 @@ public class CoordinatorUtils {
 
         sb.append( "export " )
                 .append( cluster.getName().toUpperCase() )
+                .append( "_PRIVATE_ADDRS=\"" )
+                .append( privateIpList.substring( 0, privateIpList.toString().length() - 1 ) )
+                .append( "\";" );
+
+        sb.append( "export " )
+                .append( cluster.getName().toUpperCase() )
                 .append( "_HOSTS=\"" )
                 .append( hostList.substring( 0, hostList.toString().length() - 1 ) )
+                .append( "\";" );
+
+        sb.append( "export " )
+                .append( cluster.getName().toUpperCase() )
+                .append( "_PRIVATE_HOSTS=\"" )
+                .append( privateHostList.substring( 0, privateHostList.toString().length() - 1 ) )
                 .append( "\";" );
 
         String exportVars = sb.toString();

--- a/chop/webapp/src/main/java/org/apache/usergrid/chop/webapp/coordinator/CoordinatorUtils.java
+++ b/chop/webapp/src/main/java/org/apache/usergrid/chop/webapp/coordinator/CoordinatorUtils.java
@@ -225,6 +225,29 @@ public class CoordinatorUtils {
               .append( value )
               .append( "\";" );
         }
+
+        /** export instance IPs and host names as a space separated list with ClusterName suffixed by _HOSTS and _ADDRS   */
+        StringBuilder ipList = new StringBuilder();
+        StringBuilder hostList = new StringBuilder();
+        for ( Instance temp : cluster.getInstances() ) {
+            ipList.append( temp.getPrivateIpAddress() )
+                    .append( " " );
+            hostList.append( temp.getPublicDnsName() )
+                    .append( " " );
+        }
+
+        sb.append( "export " )
+                .append( cluster.getName().toUpperCase() )
+                .append( "_ADDRS=\"" )
+                .append( ipList.substring( 0, ipList.toString().length() - 1 ) )
+                .append( "\";" );
+
+        sb.append( "export " )
+                .append( cluster.getName().toUpperCase() )
+                .append( "_HOSTS=\"" )
+                .append( hostList.substring( 0, hostList.toString().length() - 1 ) )
+                .append( "\";" );
+
         String exportVars = sb.toString();
 
         // Prepare SSH and SCP commands


### PR DESCRIPTION
Exporting instance IPs and host names as a environmental variable inside setup script. For example; if you are trying to setup ElasticSearch cluster, then ELASTICSEARCH_ADDRS and ELASTICSEARCH_HOSTS environmental variables will be exported.

See also JIRA issue USERGRID-146.
https://issues.apache.org/jira/browse/USERGRID-146

My iCLA is listed under "Salih Kardan"
