### PR TITLE
Support External Elasticsearch Storage for Webapp of Chop Module

### DIFF
--- a/chop/client/src/main/java/org/apache/usergrid/chop/client/ssh/Command.java
+++ b/chop/client/src/main/java/org/apache/usergrid/chop/client/ssh/Command.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.apache.usergrid.chop.client.ssh;
 
 

--- a/chop/client/src/main/java/org/apache/usergrid/chop/client/ssh/CommandType.java
+++ b/chop/client/src/main/java/org/apache/usergrid/chop/client/ssh/CommandType.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.apache.usergrid.chop.client.ssh;
 
 

--- a/chop/client/src/main/java/org/apache/usergrid/chop/client/ssh/Job.java
+++ b/chop/client/src/main/java/org/apache/usergrid/chop/client/ssh/Job.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.apache.usergrid.chop.client.ssh;
 
 

--- a/chop/client/src/main/java/org/apache/usergrid/chop/client/ssh/RuntimeJob.java
+++ b/chop/client/src/main/java/org/apache/usergrid/chop/client/ssh/RuntimeJob.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.apache.usergrid.chop.client.ssh;
 
 

--- a/chop/client/src/main/java/org/apache/usergrid/chop/client/ssh/SCPCommand.java
+++ b/chop/client/src/main/java/org/apache/usergrid/chop/client/ssh/SCPCommand.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.apache.usergrid.chop.client.ssh;
 
 

--- a/chop/client/src/main/java/org/apache/usergrid/chop/client/ssh/SSHCommand.java
+++ b/chop/client/src/main/java/org/apache/usergrid/chop/client/ssh/SSHCommand.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.apache.usergrid.chop.client.ssh;
 
 

--- a/chop/client/src/main/java/org/apache/usergrid/chop/client/ssh/Utils.java
+++ b/chop/client/src/main/java/org/apache/usergrid/chop/client/ssh/Utils.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.apache.usergrid.chop.client.ssh;
 
 

--- a/chop/stack/src/main/java/org/apache/usergrid/chop/stack/SetupStackState.java
+++ b/chop/stack/src/main/java/org/apache/usergrid/chop/stack/SetupStackState.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.apache.usergrid.chop.stack;
 
 

--- a/chop/webapp/src/main/java/org/apache/usergrid/chop/webapp/ChopUiConfig.java
+++ b/chop/webapp/src/main/java/org/apache/usergrid/chop/webapp/ChopUiConfig.java
@@ -27,7 +27,6 @@ import com.netflix.config.ConfigurationManager;
 import org.apache.commons.cli.CommandLine;
 import org.apache.shiro.guice.aop.ShiroAopModule;
 import org.apache.usergrid.chop.webapp.dao.SetupDao;
-import org.apache.usergrid.chop.webapp.elasticsearch.ElasticSearchClient;
 import org.apache.usergrid.chop.webapp.elasticsearch.ElasticSearchFig;
 import org.apache.usergrid.chop.webapp.elasticsearch.EsEmbedded;
 import org.apache.usergrid.chop.webapp.elasticsearch.IElasticSearchClient;

--- a/chop/webapp/src/main/java/org/apache/usergrid/chop/webapp/ChopUiJarLauncher.java
+++ b/chop/webapp/src/main/java/org/apache/usergrid/chop/webapp/ChopUiJarLauncher.java
@@ -29,6 +29,6 @@ public class ChopUiJarLauncher {
 
     public static void main(String[] args) throws Throwable {
         JarJarClassLoader cl = new JarJarClassLoader();
-        cl.invokeMain("org.apache.usergrid.chop.webapp.ChopUiJettyRunner", args);
+        cl.invokeMain(ChopUiJettyRunner.class.getCanonicalName(), args);
     }
 }

--- a/chop/webapp/src/main/java/org/apache/usergrid/chop/webapp/coordinator/rest/PropertiesResource.java
+++ b/chop/webapp/src/main/java/org/apache/usergrid/chop/webapp/coordinator/rest/PropertiesResource.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.apache.usergrid.chop.webapp.coordinator.rest;
 
 

--- a/chop/webapp/src/main/java/org/apache/usergrid/chop/webapp/elasticsearch/ElasticSearchClient.java
+++ b/chop/webapp/src/main/java/org/apache/usergrid/chop/webapp/elasticsearch/ElasticSearchClient.java
@@ -29,7 +29,6 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.transport.InetSocketTransportAddress;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import sun.rmi.runtime.Log;
 
 
 @Singleton
@@ -46,8 +45,7 @@ public class ElasticSearchClient implements IElasticSearchClient {
     @Inject
     private ElasticSearchFig elasticSearchFig;
 
-    public Client start()
-    {
+    public Client start() {
         Settings settings = ImmutableSettings.settingsBuilder().build();
         LOG.info("Starting Elasticsearch on {}", elasticSearchFig.getTransportHost() + ":" +
                 elasticSearchFig.getTransportPort());

--- a/chop/webapp/src/main/java/org/apache/usergrid/chop/webapp/elasticsearch/ElasticSearchClient.java
+++ b/chop/webapp/src/main/java/org/apache/usergrid/chop/webapp/elasticsearch/ElasticSearchClient.java
@@ -27,10 +27,15 @@ import org.elasticsearch.client.transport.TransportClient;
 import org.elasticsearch.common.settings.ImmutableSettings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.transport.InetSocketTransportAddress;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import sun.rmi.runtime.Log;
 
 
 @Singleton
 public class ElasticSearchClient implements IElasticSearchClient {
+
+    private final static Logger LOG = LoggerFactory.getLogger(ElasticSearchClient.class);
 
     private Client client;
     private String host;
@@ -39,16 +44,21 @@ public class ElasticSearchClient implements IElasticSearchClient {
 
 
     @Inject
-    public ElasticSearchClient(ElasticSearchFig elasticFig) {
+    private ElasticSearchFig elasticSearchFig;
+
+    public Client start()
+    {
         Settings settings = ImmutableSettings.settingsBuilder().build();
-
+        LOG.info("Starting Elasticsearch on {}", elasticSearchFig.getTransportHost() + ":" +
+                elasticSearchFig.getTransportPort());
         client = new TransportClient(settings).addTransportAddress(
-                new InetSocketTransportAddress(elasticFig.getTransportHost(), elasticFig.getTransportPort()));
-        port = elasticFig.getTransportPort();
-        host = elasticFig.getTransportHost();
-        clusterName = elasticFig.getClusterName();
+                new InetSocketTransportAddress(elasticSearchFig.getTransportHost(),
+                        elasticSearchFig.getTransportPort()));
+        port = elasticSearchFig.getTransportPort();
+        host = elasticSearchFig.getTransportHost();
+        clusterName = elasticSearchFig.getClusterName();
+        return client;
     }
-
 
     @Override
     public Client getClient() {
@@ -72,7 +82,6 @@ public class ElasticSearchClient implements IElasticSearchClient {
     public String getClusterName() {
         return clusterName;
     }
-
 
     @Override
     public String toString() {

--- a/chop/webapp/src/main/java/org/apache/usergrid/chop/webapp/elasticsearch/IElasticSearchClient.java
+++ b/chop/webapp/src/main/java/org/apache/usergrid/chop/webapp/elasticsearch/IElasticSearchClient.java
@@ -37,4 +37,6 @@ public interface IElasticSearchClient {
 
     @JsonProperty
     String getClusterName();
+
+    Client start();
 }

--- a/chop/webapp/src/test/java/org/apache/usergrid/chop/webapp/elasticsearch/ESSuiteTest.java
+++ b/chop/webapp/src/test/java/org/apache/usergrid/chop/webapp/elasticsearch/ESSuiteTest.java
@@ -118,8 +118,8 @@ public class ESSuiteTest {
         LOG.info( "Setting up sample data for elasticsearch Dao tests..." );
 
         Injector injector = Guice.createInjector( new ChopUiModule() );
-        IElasticSearchClient esClient = injector.getInstance(IElasticSearchClient.class);
-        esClient.start();
+        IElasticSearchClient elasticSearchClient = injector.getInstance(IElasticSearchClient.class);
+        elasticSearchClient.start();
 
         setupUsers( injector );
         setupModules( injector );

--- a/chop/webapp/src/test/java/org/apache/usergrid/chop/webapp/elasticsearch/ESSuiteTest.java
+++ b/chop/webapp/src/test/java/org/apache/usergrid/chop/webapp/elasticsearch/ESSuiteTest.java
@@ -118,6 +118,8 @@ public class ESSuiteTest {
         LOG.info( "Setting up sample data for elasticsearch Dao tests..." );
 
         Injector injector = Guice.createInjector( new ChopUiModule() );
+        IElasticSearchClient esClient = injector.getInstance(IElasticSearchClient.class);
+        esClient.start();
 
         setupUsers( injector );
         setupModules( injector );


### PR DESCRIPTION
This pull request enables webapp of chop module to use an external Elasticsearch instance or cluster. Also some missing ASL headers are added.

See also JIRA Issue USERGRID-152
https://issues.apache.org/jira/browse/USERGRID-152

My ICLA is listed under "Furkan Bıçak"
