### PR TITLE
Adding a login function to admin users in javascript sdk

### DIFF
--- a/sdks/html5-javascript/usergrid.js
+++ b/sdks/html5-javascript/usergrid.js
@@ -1055,6 +1055,46 @@ function doCallback(callback, params, context) {
             doCallback(callback, [ err, response, user ]);
         });
     };
+    
+      /*
+   *
+   *  A public method to log in an admin user - stores the token for later use
+   *
+   *  @method adminlogin
+   *  @public
+   *  @params {string} username
+   *  @params {string} password
+   *  @param {function} callback
+   *  @return {callback} callback(err, data)
+   */
+    Usergrid.Client.prototype.adminlogin = function(username, password, callback) {
+        var self = this;
+        var options = {
+            method: "POST",
+            endpoint:'management/token',
+            body: {
+                username: username,
+                password: password,
+                grant_type: "password"
+            },
+            mQuery:true
+        };
+        self.request(options, function(err, response) {
+            var user = {};
+            if (err) {
+                if (self.logging) console.log("error trying to log user in");
+            } else {
+                var options = {
+                    client: self,
+                    data: response.user
+                };
+                user = new Usergrid.Entity(options);
+                self.setToken(response.access_token);
+            }
+            doCallback(callback, [ err, response, user ]);
+        });
+    };
+    
     Usergrid.Client.prototype.reAuthenticateLite = function(callback) {
         var self = this;
         var options = {

--- a/stack/core/src/main/java/org/apache/usergrid/persistence/AbstractEntity.java
+++ b/stack/core/src/main/java/org/apache/usergrid/persistence/AbstractEntity.java
@@ -267,11 +267,11 @@ public abstract class AbstractEntity implements Entity {
     @Override
     @JsonAnySetter
     public void setDynamicProperty( String key, Object value ) {
-        if (value.equals("")) {
-			if (dynamic_properties.containsKey(key)) {
-				dynamic_properties.remove(key);
-			}
-		} else {
+        if (value.equals("")) {		//If value is empty remove the coresponding key from entity proerties
+		if (dynamic_properties.containsKey(key)) {
+			dynamic_properties.remove(key);
+		}
+		} else {	// else add that property	
 			dynamic_properties.put(key, value);
 		}
     }


### PR DESCRIPTION
With this function developers can login as admin by adding the following code after initializing the usergrid client.

client.adminlogin("superuser","superuser"); 

related improvement in jire = https://issues.apache.org/jira/browse/USERGRID-167

PS. please ignore "Update AbstractEntity.java" commit in this pull request.
