### PR TITLE
convert JSONArray into string before saving results to ES

### DIFF
--- a/chop/webapp/src/main/java/org/apache/usergrid/chop/webapp/coordinator/rest/RunManagerResource.java
+++ b/chop/webapp/src/main/java/org/apache/usergrid/chop/webapp/coordinator/rest/RunManagerResource.java
@@ -219,11 +219,20 @@ public class RunManagerResource extends TestableResource implements RestParams {
                     failureCount
             );
             if( failureCount != 0 ) {
-                runResult.setFailures( Util.getString( jsonResult, "failures" ) );
+                try {
+                    for( Object result : runResults ) {
+                        JSONObject failures = ( JSONObject ) result;
+                        JSONArray obj = ( JSONArray ) failures.get( "failures" );
+                        runResult.setFailures( obj.toJSONString() );
+                        LOG.info( "Saving run results into Elastic Search." );
+                    }
+                }catch ( Exception e ){
+                    LOG.warn( "Could not serialize runResults JSON object", e );
+                }
             }
 
             if ( runResultDao.save( runResult ) ) {
-                LOG.info( "Saved run result: {}", runResult );
+                LOG.info( "Saved run result.");
             }
         }
 


### PR DESCRIPTION
If chopped tests fail, then in the resulting JSON file "failures" property will be an JSONArray. We need to convert this JSONArray into string in order not to get  ClassCastException while saving this JSON file into Elastic Search.

My iCLA is listed under "Salih Kardan"
