### PR TITLE
[chop] preserve page status on refresh & layout fixes

### DIFF
--- a/chop/webapp/src/main/java/org/apache/usergrid/chop/webapp/view/log/LogLayout.java
+++ b/chop/webapp/src/main/java/org/apache/usergrid/chop/webapp/view/log/LogLayout.java
@@ -25,15 +25,15 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.RandomAccessFile;
 
+import com.vaadin.ui.Button;
+import com.vaadin.ui.Alignment;
+import com.vaadin.ui.TextArea;
+import com.vaadin.ui.VerticalLayout;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.vaadin.ui.AbsoluteLayout;
-import com.vaadin.ui.Button;
-import com.vaadin.ui.TextArea;
 
-
-public class LogLayout extends AbsoluteLayout {
+public class LogLayout extends VerticalLayout {
 
     private final static Logger LOG = LoggerFactory.getLogger( LogLayout.class );
 
@@ -44,6 +44,7 @@ public class LogLayout extends AbsoluteLayout {
 
     public LogLayout() {
         initializeUIComponents();
+        this.setSizeFull();
     }
 
 
@@ -64,10 +65,12 @@ public class LogLayout extends AbsoluteLayout {
         catch ( FileNotFoundException e ) {
             LOG.error( "Error while accessing file {}: {}", file, e );
         }
-        logArea.setWidth( "800px" );
-        logArea.setHeight( "530px" );
+        logArea.setHeight( "100%");
+        logArea.setWidth( "100%");
         getApplicationLog();
-        addComponent( logArea, "left: 250px; top: 20px;" );
+        addComponent( logArea );
+        this.setComponentAlignment(logArea, Alignment.TOP_CENTER);
+        this.setExpandRatio( logArea, 0.95f );
     }
 
 
@@ -96,13 +99,16 @@ public class LogLayout extends AbsoluteLayout {
 
     private void addRefreshButton()  {
         Button button = new Button( "Refresh" );
-        button.setWidth( "100px" );
-        button.addClickListener( new Button.ClickListener() {
-            public void buttonClick( Button.ClickEvent event ) {
+        button.setWidth("100px");
+        button.addClickListener(new Button.ClickListener() {
+            public void buttonClick(Button.ClickEvent event) {
                 loadData();
             }
-        } );
-        addComponent( button, "left: 585px; top: 570px;" );
+        });
+        addComponent( button );
+        setComponentAlignment( button, Alignment.BOTTOM_CENTER );
+        this.setExpandRatio( button, 0.05f );
+
     }
 
 

--- a/chop/webapp/src/main/java/org/apache/usergrid/chop/webapp/view/log/LogLayout.java
+++ b/chop/webapp/src/main/java/org/apache/usergrid/chop/webapp/view/log/LogLayout.java
@@ -65,11 +65,11 @@ public class LogLayout extends VerticalLayout {
         catch ( FileNotFoundException e ) {
             LOG.error( "Error while accessing file {}: {}", file, e );
         }
-        logArea.setHeight( "100%");
-        logArea.setWidth( "100%");
+        logArea.setHeight( "100%" );
+        logArea.setWidth( "100%" );
         getApplicationLog();
         addComponent( logArea );
-        this.setComponentAlignment(logArea, Alignment.TOP_CENTER);
+        this.setComponentAlignment( logArea, Alignment.TOP_CENTER );
         this.setExpandRatio( logArea, 0.95f );
     }
 
@@ -100,8 +100,8 @@ public class LogLayout extends VerticalLayout {
     private void addRefreshButton()  {
         Button button = new Button( "Refresh" );
         button.setWidth("100px");
-        button.addClickListener(new Button.ClickListener() {
-            public void buttonClick(Button.ClickEvent event) {
+        button.addClickListener( new Button.ClickListener() {
+            public void buttonClick( Button.ClickEvent event ) {
                 loadData();
             }
         });

--- a/chop/webapp/src/main/java/org/apache/usergrid/chop/webapp/view/main/Login.java
+++ b/chop/webapp/src/main/java/org/apache/usergrid/chop/webapp/view/main/Login.java
@@ -47,9 +47,6 @@ public class Login extends UI {
 
     private void addItems() {
         // Set default values
-        usernameField.setValue( "user" );
-        passwordField.setValue( "pass" );
-
         FormLayout formLayout = addFormLayout();
         formLayout.addComponent( title );
         formLayout.addComponent( usernameField );

--- a/chop/webapp/src/main/java/org/apache/usergrid/chop/webapp/view/main/Login.java
+++ b/chop/webapp/src/main/java/org/apache/usergrid/chop/webapp/view/main/Login.java
@@ -1,5 +1,6 @@
 package org.apache.usergrid.chop.webapp.view.main;
 
+import com.vaadin.annotations.PreserveOnRefresh;
 import com.vaadin.server.VaadinRequest;
 import com.vaadin.shared.ui.label.ContentMode;
 import com.vaadin.ui.Notification;
@@ -16,6 +17,8 @@ import org.apache.commons.lang.StringUtils;
 import org.apache.usergrid.chop.webapp.service.shiro.ShiroRealm;
 import org.apache.usergrid.chop.webapp.view.util.JavaScriptUtil;
 
+
+@PreserveOnRefresh
 public class Login extends UI {
 
     private final Label title = new Label ( "<h3>Login</h3>", ContentMode.HTML );
@@ -23,12 +26,15 @@ public class Login extends UI {
     private final PasswordField passwordField = new PasswordField( "Password:" );
     private final Button loginButton = new Button( "Login" );
 
-    AbsoluteLayout mainLayout;
+    VerticalLayout mainLayout;
     MainView mainView = new MainView();
 
     @Override
     protected void init(VaadinRequest vaadinRequest) {
-        mainLayout  = addMainLayout();
+        mainLayout  = new VerticalLayout();
+        mainLayout.setSizeFull();
+        setContent( mainLayout );
+
         addItems();
         loadScripts();
     }
@@ -39,23 +45,10 @@ public class Login extends UI {
         JavaScriptUtil.loadFile( "js/jquery.flot.min.js" );
     }
 
-    private AbsoluteLayout addMainLayout() {
-
-        AbsoluteLayout absoluteLayout = new AbsoluteLayout();
-        absoluteLayout.setWidth( "1300px" );
-        absoluteLayout.setHeight( "700px" );
-
-        VerticalLayout verticalLayout = new VerticalLayout();
-        verticalLayout.setSizeFull();
-        verticalLayout.addComponent( absoluteLayout );
-        verticalLayout.setComponentAlignment( absoluteLayout, Alignment.MIDDLE_CENTER );
-
-        setContent( verticalLayout );
-
-        return absoluteLayout;
-    }
-
     private void addItems() {
+        // Set default values
+        usernameField.setValue( "user" );
+        passwordField.setValue( "pass" );
 
         FormLayout formLayout = addFormLayout();
         formLayout.addComponent( title );
@@ -72,8 +65,8 @@ public class Login extends UI {
         formLayout.setHeight( "200px" );
         formLayout.addStyleName( "outlined" );
         formLayout.setSpacing( true );
-        mainLayout.addComponent(formLayout, "left: 350px; top: 50px;");
-
+        mainLayout.addComponent( formLayout );
+        mainLayout.setComponentAlignment( formLayout, Alignment.MIDDLE_CENTER );
         return formLayout;
     }
 

--- a/chop/webapp/src/main/java/org/apache/usergrid/chop/webapp/view/main/MainView.java
+++ b/chop/webapp/src/main/java/org/apache/usergrid/chop/webapp/view/main/MainView.java
@@ -18,7 +18,6 @@
  */
 package org.apache.usergrid.chop.webapp.view.main;
 
-
 import com.vaadin.server.VaadinService;
 import com.vaadin.ui.AbsoluteLayout;
 import com.vaadin.ui.Alignment;
@@ -40,26 +39,27 @@ import org.apache.usergrid.chop.webapp.view.user.UserListWindow;
 public class MainView extends VerticalLayout implements ModuleSelectListener {
 
     private TabSheetManager tabSheetManager;
-    AbsoluteLayout tabSheet;
+    VerticalLayout tabSheet;
     HorizontalLayout buttons;
 
 
     MainView( ) {
         this.setHeight( "100%" );
-//        this.setSizeUndefined();
+
+        VerticalLayout verticalLayoutForButtons = new VerticalLayout();
+        verticalLayoutForButtons.setSizeFull();
 
         buttons = addButtons();
         this.addComponent( buttons );
         setComponentAlignment( buttons , Alignment.TOP_CENTER );
 
         tabSheet = addTabSheet();
+        tabSheet.setSizeFull();
         this.addComponent( tabSheet );
         this.setComponentAlignment( tabSheet, Alignment.TOP_CENTER );
 
         this.setExpandRatio( buttons, 0.04f );
         this.setExpandRatio( tabSheet, 0.96f );
-
-        tabSheet.setSizeFull();
     }
 
     private HorizontalLayout addButtons() {
@@ -78,54 +78,57 @@ public class MainView extends VerticalLayout implements ModuleSelectListener {
 
         /**      Runners Button    */
         Button runners = new Button( "Runners" );
-        horizontalLayout.addComponent(runners);
+        horizontalLayout.addComponent( runners );
         runners.addClickListener( new Button.ClickListener() {
             @Override
             public void buttonClick(Button.ClickEvent clickEvent) {
-                tabSheetManager.addTab(new RunnersLayout(), "Runners");
+                tabSheetManager.addTabWithVerticalLayout( new RunnersLayout(), "Runners" );
             }
         });
 
         /**      Users Button    */
-        Button users = new Button("Users");
+        Button users = new Button( "Users" );
         horizontalLayout.addComponent( users );
         users.addClickListener( new Button.ClickListener() {
             @Override
-            public void buttonClick(Button.ClickEvent clickEvent) {
-                UI.getCurrent().addWindow(new UserListWindow(tabSheetManager));
+            public void buttonClick( Button.ClickEvent clickEvent ) {
+                UI.getCurrent().addWindow( new UserListWindow( tabSheetManager ) );
             }
         });
 
         /**      Logs Button    */
-        Button logs = new Button("Logs");
+        Button logs = new Button( "Logs" );
         horizontalLayout.addComponent( logs );
-        logs.addClickListener( new Button.ClickListener() {
+        logs.addClickListener(new Button.ClickListener() {
             @Override
-            public void buttonClick(Button.ClickEvent clickEvent) {
-                tabSheetManager.addTab(new LogLayout(), "Logs");
+            public void buttonClick( Button.ClickEvent clickEvent ) {
+                tabSheetManager.addTabWithVerticalLayout( new LogLayout(), "Logs");
             }
         });
 
         /**      Logout Button    */
-        Button logout = new Button("Logout");
+        Button logout = new Button( "Logout" );
         horizontalLayout.addComponent( logout );
-        logout.addClickListener(new Button.ClickListener() {
+        logout.addClickListener( new Button.ClickListener() {
             @Override
-            public void buttonClick(Button.ClickEvent clickEvent) {
+            public void buttonClick( Button.ClickEvent clickEvent ) {
                 ShiroRealm.logout();
                 redirectToMainView();
             }
         });
+        float weight = logout.getHeight();
+        horizontalLayout.setHeight( String.valueOf( weight ) );
         return horizontalLayout;
     }
 
-    private AbsoluteLayout addTabSheet(  ) {
-        AbsoluteLayout tabLayout = new AbsoluteLayout();
+    private VerticalLayout addTabSheet() {
+        VerticalLayout tabLayout = new VerticalLayout();
         TabSheet tabSheet = new TabSheet();
-        tabSheet.setHeight( "650px" );
+        tabSheet.setHeight( "100%" );
 
-        tabSheetManager = new TabSheetManager(tabSheet );
-        tabLayout.addComponent(tabSheet, "left: 0px; top: 7px;");
+        tabSheetManager = new TabSheetManager( tabSheet );
+        tabLayout.addComponent( tabSheet );
+
         return tabLayout;
     }
 

--- a/chop/webapp/src/main/java/org/apache/usergrid/chop/webapp/view/main/MainView.java
+++ b/chop/webapp/src/main/java/org/apache/usergrid/chop/webapp/view/main/MainView.java
@@ -102,7 +102,7 @@ public class MainView extends VerticalLayout implements ModuleSelectListener {
         logs.addClickListener(new Button.ClickListener() {
             @Override
             public void buttonClick( Button.ClickEvent clickEvent ) {
-                tabSheetManager.addTabWithVerticalLayout( new LogLayout(), "Logs");
+                tabSheetManager.addTabWithVerticalLayout( new LogLayout(), "Logs" );
             }
         });
 

--- a/chop/webapp/src/main/java/org/apache/usergrid/chop/webapp/view/main/MainView.java
+++ b/chop/webapp/src/main/java/org/apache/usergrid/chop/webapp/view/main/MainView.java
@@ -20,101 +20,114 @@ package org.apache.usergrid.chop.webapp.view.main;
 
 
 import com.vaadin.server.VaadinService;
+import com.vaadin.ui.AbsoluteLayout;
+import com.vaadin.ui.Alignment;
+import com.vaadin.ui.HorizontalLayout;
+import com.vaadin.ui.VerticalLayout;
+import com.vaadin.ui.Button;
+import com.vaadin.ui.UI;
+import com.vaadin.ui.TabSheet;
 import org.apache.usergrid.chop.webapp.service.chart.Params;
 import org.apache.usergrid.chop.webapp.service.shiro.ShiroRealm;
-
 import org.apache.usergrid.chop.webapp.view.chart.layout.OverviewChartLayout;
 import org.apache.usergrid.chop.webapp.view.log.LogLayout;
 import org.apache.usergrid.chop.webapp.view.module.ModuleListWindow;
 import org.apache.usergrid.chop.webapp.view.module.ModuleSelectListener;
 import org.apache.usergrid.chop.webapp.view.runner.RunnersLayout;
 import org.apache.usergrid.chop.webapp.view.user.UserListWindow;
-import com.vaadin.ui.AbsoluteLayout;
-import com.vaadin.ui.Alignment;
-import com.vaadin.ui.Button;
-import com.vaadin.ui.TabSheet;
-import com.vaadin.ui.UI;
-import com.vaadin.ui.VerticalLayout;
 
 
-public class MainView extends AbsoluteLayout implements ModuleSelectListener {
+public class MainView extends VerticalLayout implements ModuleSelectListener {
 
     private TabSheetManager tabSheetManager;
+    AbsoluteLayout tabSheet;
+    HorizontalLayout buttons;
+
 
     MainView( ) {
-        addButtons( this );
-        addTabSheet( this );
+        this.setHeight( "100%" );
+//        this.setSizeUndefined();
+
+        buttons = addButtons();
+        this.addComponent( buttons );
+        setComponentAlignment( buttons , Alignment.TOP_CENTER );
+
+        tabSheet = addTabSheet();
+        this.addComponent( tabSheet );
+        this.setComponentAlignment( tabSheet, Alignment.TOP_CENTER );
+
+        this.setExpandRatio( buttons, 0.04f );
+        this.setExpandRatio( tabSheet, 0.96f );
+
+        tabSheet.setSizeFull();
     }
 
-    private AbsoluteLayout addMainLayout() {
+    private HorizontalLayout addButtons() {
+        HorizontalLayout horizontalLayout = new HorizontalLayout();
 
-        AbsoluteLayout absoluteLayout = new AbsoluteLayout();
-        absoluteLayout.setWidth( "1300px" );
-        absoluteLayout.setHeight( "700px" );
-
-        VerticalLayout verticalLayout = new VerticalLayout();
-        verticalLayout.setSizeFull();
-        verticalLayout.addComponent( absoluteLayout );
-        verticalLayout.setComponentAlignment( absoluteLayout, Alignment.MIDDLE_CENTER );
-        this.addComponent(verticalLayout);
-
-        return absoluteLayout;
-    }
-
-
-    private void addButtons( AbsoluteLayout mainLayout ) {
-
-        addButton( mainLayout, 350, "Modules", new Button.ClickListener() {
-            public void buttonClick( Button.ClickEvent event ) {
+        /**      Modules Button    */
+        Button modules = new Button( "Modules" );
+        horizontalLayout.addComponent( modules );
+        modules.addClickListener( new Button.ClickListener() {
+            @Override
+            public void buttonClick(Button.ClickEvent clickEvent) {
                 UI.getCurrent().addWindow( new ModuleListWindow( MainView.this ) );
             }
         });
 
-        addButton( mainLayout, 460, "Runners", new Button.ClickListener() {
-            public void buttonClick( Button.ClickEvent event ) {
+
+        /**      Runners Button    */
+        Button runners = new Button( "Runners" );
+        horizontalLayout.addComponent(runners);
+        runners.addClickListener( new Button.ClickListener() {
+            @Override
+            public void buttonClick(Button.ClickEvent clickEvent) {
                 tabSheetManager.addTab(new RunnersLayout(), "Runners");
             }
         });
 
-        addButton( mainLayout, 570, "Users", new Button.ClickListener() {
-            public void buttonClick( Button.ClickEvent event ) {
+        /**      Users Button    */
+        Button users = new Button("Users");
+        horizontalLayout.addComponent( users );
+        users.addClickListener( new Button.ClickListener() {
+            @Override
+            public void buttonClick(Button.ClickEvent clickEvent) {
                 UI.getCurrent().addWindow(new UserListWindow(tabSheetManager));
             }
         });
 
-        addButton( mainLayout, 680, "Logs", new Button.ClickListener() {
-            public void buttonClick( Button.ClickEvent event ) {
+        /**      Logs Button    */
+        Button logs = new Button("Logs");
+        horizontalLayout.addComponent( logs );
+        logs.addClickListener( new Button.ClickListener() {
+            @Override
+            public void buttonClick(Button.ClickEvent clickEvent) {
                 tabSheetManager.addTab(new LogLayout(), "Logs");
             }
         });
 
-        addButton( mainLayout, 790, "Logout", new Button.ClickListener() {
-            public void buttonClick( Button.ClickEvent event ) {
+        /**      Logout Button    */
+        Button logout = new Button("Logout");
+        horizontalLayout.addComponent( logout );
+        logout.addClickListener(new Button.ClickListener() {
+            @Override
+            public void buttonClick(Button.ClickEvent clickEvent) {
                 ShiroRealm.logout();
                 redirectToMainView();
             }
         });
+        return horizontalLayout;
     }
 
-
-    private static void addButton( AbsoluteLayout mainLayout, int left, String caption, Button.ClickListener listener ) {
-
-        Button button = new Button( caption );
-        button.setWidth( "100px" );
-        button.addClickListener( listener );
-
-        mainLayout.addComponent( button, String.format( "left: %spx; top: 0px;", left ) );
-    }
-
-
-    private void addTabSheet( AbsoluteLayout mainLayout ) {
+    private AbsoluteLayout addTabSheet(  ) {
+        AbsoluteLayout tabLayout = new AbsoluteLayout();
         TabSheet tabSheet = new TabSheet();
         tabSheet.setHeight( "650px" );
 
         tabSheetManager = new TabSheetManager(tabSheet );
-        mainLayout.addComponent( tabSheet, "left: 0px; top: 50px;" );
+        tabLayout.addComponent(tabSheet, "left: 0px; top: 7px;");
+        return tabLayout;
     }
-
 
     @Override
     public void onModuleSelect( String moduleId ) {

--- a/chop/webapp/src/main/java/org/apache/usergrid/chop/webapp/view/main/TabSheetManager.java
+++ b/chop/webapp/src/main/java/org/apache/usergrid/chop/webapp/view/main/TabSheetManager.java
@@ -21,6 +21,7 @@ package org.apache.usergrid.chop.webapp.view.main;
 
 import com.vaadin.ui.AbsoluteLayout;
 import com.vaadin.ui.TabSheet;
+import com.vaadin.ui.VerticalLayout;
 
 
 public class TabSheetManager {
@@ -33,6 +34,12 @@ public class TabSheetManager {
 
     public void addTab( AbsoluteLayout layout, String caption ) {
         removeAll();
+        tabSheet.addTab( layout, caption );
+    }
+
+    public void addTabWithVerticalLayout(VerticalLayout layout, String caption) {
+        removeAll();
+        tabSheet.setSizeFull();
         tabSheet.addTab( layout, caption );
     }
 

--- a/chop/webapp/src/main/java/org/apache/usergrid/chop/webapp/view/main/TabSheetManager.java
+++ b/chop/webapp/src/main/java/org/apache/usergrid/chop/webapp/view/main/TabSheetManager.java
@@ -37,7 +37,7 @@ public class TabSheetManager {
         tabSheet.addTab( layout, caption );
     }
 
-    public void addTabWithVerticalLayout(VerticalLayout layout, String caption) {
+    public void addTabWithVerticalLayout( VerticalLayout layout, String caption ) {
         removeAll();
         tabSheet.setSizeFull();
         tabSheet.addTab( layout, caption );
@@ -47,5 +47,4 @@ public class TabSheetManager {
         // BUG: Showing two charts doesn't work, thus we have to close others to display a new one.
         tabSheet.removeAllComponents();
     }
-
 }

--- a/chop/webapp/src/main/java/org/apache/usergrid/chop/webapp/view/runner/RunnersLayout.java
+++ b/chop/webapp/src/main/java/org/apache/usergrid/chop/webapp/view/runner/RunnersLayout.java
@@ -25,6 +25,11 @@ import java.util.Date;
 import java.util.List;
 import java.util.Map;
 
+import com.vaadin.ui.Accordion;
+import com.vaadin.ui.Alignment;
+import com.vaadin.ui.Button;
+import com.vaadin.ui.VerticalLayout;
+import com.vaadin.ui.Table;
 import org.apache.commons.lang.StringUtils;
 
 import org.apache.usergrid.chop.api.Module;
@@ -37,15 +42,9 @@ import org.apache.usergrid.chop.webapp.dao.model.RunnerGroup;
 import org.apache.usergrid.chop.webapp.service.InjectorFactory;
 import org.apache.usergrid.chop.webapp.service.runner.RunnerService;
 import org.apache.usergrid.chop.webapp.service.runner.RunnerServiceImpl;
-import org.apache.usergrid.chop.webapp.service.runner.RunnerServiceMock;
-
-import com.vaadin.ui.AbsoluteLayout;
-import com.vaadin.ui.Accordion;
-import com.vaadin.ui.Button;
-import com.vaadin.ui.Table;
 
 
-public class RunnersLayout extends AbsoluteLayout {
+public class RunnersLayout extends VerticalLayout {
 
     private static final DateFormat DATE_FORMAT = new SimpleDateFormat("HH:mm:ss");
 
@@ -80,14 +79,16 @@ public class RunnersLayout extends AbsoluteLayout {
             }
         });
 
-        addComponent( button, "left: 585px; top: 570px;" );
+        addComponent( button );
+        this.setComponentAlignment( button, Alignment.BOTTOM_CENTER );
     }
 
 
     private void addAccordion() {
         accordion.setWidth( "800px" );
         accordion.setHeight( "530px" );
-        addComponent( accordion, "left: 250px; top: 20px;" );
+        addComponent( accordion );
+        this.setComponentAlignment( accordion, Alignment.MIDDLE_CENTER );
     }
 
 

--- a/chop/webapp/src/main/java/org/apache/usergrid/chop/webapp/view/user/UserLayout.java
+++ b/chop/webapp/src/main/java/org/apache/usergrid/chop/webapp/view/user/UserLayout.java
@@ -31,7 +31,6 @@ import org.apache.usergrid.chop.webapp.dao.ProviderParamsDao;
 import org.apache.usergrid.chop.webapp.dao.UserDao;
 import org.apache.usergrid.chop.webapp.dao.model.BasicProviderParams;
 import org.apache.usergrid.chop.webapp.service.InjectorFactory;
-import org.apache.usergrid.chop.webapp.view.main.MainView;
 import org.apache.usergrid.chop.webapp.view.main.TabSheetManager;
 
 import com.vaadin.ui.AbsoluteLayout;


### PR DESCRIPTION
This pull requests fixing two problems:
- Coordinator web UI could not preserve its state when page refreshes
- Layouts logs and runners tabs did not fit well to browser window. 

My iCLA is listed under "Salih Kardan"
