### PR TITLE
Setup the stack with latest runner count information

### DIFF
--- a/chop/webapp/src/main/java/org/apache/usergrid/chop/webapp/coordinator/StackCoordinator.java
+++ b/chop/webapp/src/main/java/org/apache/usergrid/chop/webapp/coordinator/StackCoordinator.java
@@ -122,15 +122,19 @@ public class StackCoordinator {
     public CoordinatedStack setupStack( Stack stack, User user, Commit commit, Module module, int runnerCount ) {
 
         CoordinatedStack coordinatedStack = getCoordinatedStack( stack, user, commit, module );
-        if ( coordinatedStack != null ) {
+        if ( coordinatedStack != null && coordinatedStack.getRunnerCount() == runnerCount ) {
             LOG.info( "Stack {} is already registered", stack.getName() );
             if( coordinatedStack.getSetupState() == SetupStackState.SetUp ) {
                 return coordinatedStack;
             }
         }
-        else {
-            coordinatedStack = new CoordinatedStack( stack, user, commit, module, runnerCount );
+        else if ( coordinatedStack != null && coordinatedStack.getRunnerCount() != runnerCount  ) {
+            LOG.info( "Stack {} is registered with different runner count, first removing the old stack", stack.getName() );
+            registeredStacks.remove( coordinatedStack.hashCode() );
         }
+
+        LOG.info( "Registering new stack {}...", stack.getName() );
+        coordinatedStack = new CoordinatedStack( stack, user, commit, module, runnerCount );
 
         LOG.info( "Starting setup stack thread of {}...", stack.getName() );
         synchronized ( coordinatedStack ) {


### PR DESCRIPTION
This pull request fixes the following bug:
- When a runner.jar deployed with a runnerCount which is different from the one when setup goal is called, then the stack is set up with the old runner count. Fix this bug so that stack is set up with the latest runner count information.

My ICLA is listed under "Furkan Bıçak"
